### PR TITLE
Non-Functional Buy Page

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,9 @@
 name: Rust
 
+permissions:
+  checks: write
+  pull-requests: write
+
 on:
   push:
     branches: [ "master" ]
@@ -25,19 +29,34 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       - name: Migrate database
         run: |
           sudo apt-get install libpq-dev -y
           cargo install sqlx-cli --features postgres
           SKIP_DOCKER=true ./scripts/init_db.sh
+
       - uses: actions-rs/cargo@v1
         with:
           command: build
+
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - uses: giraffate/clippy-action@v1
+        with:
+          reporter: 'github-pr-review'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clippy_flags: --all-features --all-targets -- -Dwarnings
+          workdir: ./${{ matrix.project }}
+          fail_on_error: true
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -262,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +380,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -685,6 +714,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
+
+[[package]]
 name = "httparse"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +957,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +991,24 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "multer"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15d522be0a9c3e46fd2632e272d178f56387bdb5c9fbb3a36c649062e9b5219"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1317,6 +1380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1418,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1752,12 +1830,16 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "derive_more",
  "dotenv",
  "maud",
  "serde",
  "serde_with",
  "sqlx",
+ "thiserror",
  "tokio",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1938,6 +2020,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2043,31 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2032,6 +2152,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-axum = { version = "0.7", features = ["macros"] }
+axum = { version = "0.7", features = ["macros", "multipart"] }
 tokio = { version = "1.37", features = ["full"] }
 sqlx = { version = "0.8", features = ["postgres", "macros", "migrate", "runtime-tokio", "chrono", "uuid"] }
 serde = "1.0"
@@ -17,3 +17,7 @@ dotenv = "0.15"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 maud = { version = "*", features = ["axum"] }
+derive_more = "0.99"
+tower = { version = "0.4", features = ["util"] }
+tower-http = { version = "0.5.0", features = ["fs", "trace"] }
+thiserror = "1.0.63"

--- a/migrations/0001_initial.sql
+++ b/migrations/0001_initial.sql
@@ -18,10 +18,8 @@ CREATE TABLE products (
 );
 
 CREATE TABLE product_aliases (
+  alias_name VARCHAR(128) PRIMARY KEY NOT NULL,
   product_id SERIAL NOT NULL,
-  alias_name VARCHAR(128) NOT NULL,
-
-  UNIQUE(product_id, alias_name),
 
   CONSTRAINT fk_product 
     FOREIGN KEY(product_id)

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+set -e
+set -u
+set -x
 
 cargo sqlx db create
 cargo sqlx migrate run

--- a/scripts/populate_sample_data.sh
+++ b/scripts/populate_sample_data.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+set -u
+set -x
+
+SCRIPTS="$(dirname "$0")"
+
+docker exec -i postgres-stregsystemet psql -f /dev/stdin "postgres://stregsystemet:password@localhost/stregsystemet" < "$SCRIPTS/sample_data.sql"

--- a/scripts/sample_data.sql
+++ b/scripts/sample_data.sql
@@ -1,0 +1,6 @@
+INSERT INTO products(name, price, active, deactivate_after_timestamp)
+VALUES 
+  ('Øl',               700 ,  true,  NULL),
+  ('Sodavand',         1200,  true,  NULL),
+  ('Søm',              200,   false, NULL),
+  ('Fytteturs Billet', 30000, true,  '2024-09-01');

--- a/scripts/start_postgres.sh
+++ b/scripts/start_postgres.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+set -u
+set -x
+
+docker run                         \
+  -d                               \
+  --name 'postgres-stregsystemet'  \
+  -l 'postgres-stregsystemet'      \
+  -e POSTGRES_USER='stregsystemet' \
+  -e POSTGRES_PASSWORD='password'  \
+  -e POSTGRES_DB='stregsystemet'   \
+  -p 5432:5432                     \
+  docker.io/postgres:16

--- a/scripts/stop_postgres.sh
+++ b/scripts/stop_postgres.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+set -u
+set -x
+
+docker rm -f 'postgres-stregsystemet'

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,0 +1,2 @@
+pub mod product_menu_components;
+pub mod quickbuy_component;

--- a/src/components/product_menu_components.rs
+++ b/src/components/product_menu_components.rs
@@ -1,0 +1,89 @@
+use maud::{html, Markup};
+
+use crate::dso::product::Product;
+
+pub fn products_table_component(products: &[Product]) -> Markup {
+    let left_products = products.iter().step_by(2);
+    let right_products = products.iter().skip(1).step_by(2);
+
+    products_table_template_component(
+        products_table_part_component(left_products),
+        products_table_part_component(right_products),
+    )
+}
+
+pub fn clickable_products_table_component(products: &[Product], username: &str) -> Markup {
+    let left_products = products.iter().step_by(2);
+    let right_products = products.iter().skip(1).step_by(2);
+
+    products_table_template_component(
+        clickable_products_table_part_component(left_products, username),
+        clickable_products_table_part_component(right_products, username),
+    )
+}
+
+// TODO: SHIT FUCKING NAME
+fn products_table_template_component(left_products: Markup, right_products: Markup) -> Markup {
+    html! {
+        table cellpadding="2" cellspacing="2" border="0" {
+            tr {
+                td valign="top" { (left_products) }
+                td valign="top" { (right_products) }
+            }
+        }
+    }
+}
+
+fn products_table_part_component<'a, I>(products: I) -> Markup
+where
+    I: Iterator<Item = &'a Product>,
+{
+    html! {
+        table cellpadding="2" cellspacing="2" border="1" {
+            tr {
+                th { "ID" }
+                th { "Produkt" }
+                th { "Pris" }
+            }
+
+            @for product in products {
+                tr {
+                    td { (product.id) }
+                    td { (product.name) }
+                    td align="right" { (product.price) "kr" }
+                }
+            }
+        }
+    }
+}
+
+fn clickable_products_table_part_component<'a, I>(products: I, username: &str) -> Markup
+where
+    I: Iterator<Item = &'a Product>,
+{
+    html! {
+        table cellpadding="2" cellspacing="2" border="1" {
+            tr {
+                th { "Produkt" }
+                th { "Pris" }
+            }
+
+            @for product in products {
+                tr {
+                    td { (clickable_product_link_component(&product, username)) }
+                    td align="right" { (product.price) "kr" }
+                }
+            }
+        }
+    }
+}
+
+fn clickable_product_link_component(product: &Product, username: &str) -> Markup {
+    html! {
+        form method="post" action="/buy/" {
+            a href="" onclick="this.closest('form').submit(); return false;" { (product.name) }
+
+            input type="hidden" name="quickbuy" value={ (username) " " (product.id) } ;
+        }
+    }
+}

--- a/src/components/quickbuy_component.rs
+++ b/src/components/quickbuy_component.rs
@@ -1,0 +1,15 @@
+use maud::{html, Markup};
+
+pub fn quickbuy_component() -> Markup {
+    html! {
+        div class="quickbuy-container" {
+            form autocomplete="off" action="/buy/" method="post" {
+                p {
+                    label for="quickbuy" { "Quickbuy" }
+                    input tabindex="1" type="text" name="quickbuy" id="quickbuy" autofocus;
+                    input tabindex="2" type="submit" value="Køb!";
+                }
+            }
+        }
+    }
+}

--- a/src/dso.rs
+++ b/src/dso.rs
@@ -1,0 +1,2 @@
+pub mod product;
+pub mod streg_cents;

--- a/src/dso/product.rs
+++ b/src/dso/product.rs
@@ -1,0 +1,20 @@
+use maud::Render;
+use serde::{Deserialize, Serialize};
+
+use super::streg_cents::StregCents;
+
+#[derive(Deserialize, Serialize, Debug, sqlx::Type, PartialEq, Eq)]
+#[sqlx(transparent)]
+pub struct ProductId(i32);
+
+pub struct Product {
+    pub id: ProductId,
+    pub name: String,
+    pub price: StregCents,
+}
+
+impl Render for ProductId {
+    fn render_to(&self, buffer: &mut String) {
+        self.0.render_to(buffer)
+    }
+}

--- a/src/dso/streg_cents.rs
+++ b/src/dso/streg_cents.rs
@@ -1,0 +1,39 @@
+use std::fmt::Display;
+
+use maud::Render;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, sqlx::Type, PartialEq, Eq)]
+#[sqlx(transparent)]
+pub struct StregCents(i64);
+
+impl Display for StregCents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let dollars = self.0 / 100;
+        let cents = self.0 % 100;
+
+        write!(f, "{}.{:02}", dollars, cents)
+    }
+}
+
+impl Render for StregCents {
+    fn render_to(&self, buffer: &mut String) {
+        self.to_string().render_to(buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_string() {
+        let streg_cents = StregCents(725);
+        let streg_cents_zero_cents = StregCents(800);
+        let streg_cents_zero = StregCents(0);
+
+        assert_eq!(streg_cents.to_string(), "7.25");
+        assert_eq!(streg_cents_zero_cents.to_string(), "8.00");
+        assert_eq!(streg_cents_zero.to_string(), "0.00");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,32 @@
+mod components;
+mod dso;
+mod protocol;
+mod quickbuy;
+
 use std::error::Error;
 
-use axum::{debug_handler, extract::State, http::StatusCode, routing::get, Router};
+use axum::{
+    debug_handler,
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+    Form, Router,
+};
+use components::{
+    product_menu_components::{clickable_products_table_component, products_table_component},
+    quickbuy_component::quickbuy_component,
+};
 use dotenv::dotenv;
-use maud::{html, Markup};
+use dso::{
+    product::{Product, ProductId},
+    streg_cents::StregCents,
+};
+use maud::{html, Markup, DOCTYPE};
+use protocol::buy_request::BuyRequest;
+use quickbuy::parser::{parse_quickbuy_query, QuickBuyType};
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use tokio::net::TcpListener;
+use tower_http::services::ServeDir;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -29,7 +51,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 fn app(pool: PgPool) -> Router {
     let router = Router::new()
         .route("/api/user/create", get(create_user))
-        .route("/api/user/all", get(get_users));
+        .route("/api/user/all", get(get_users))
+        .route("/", get(index))
+        .route("/buy/", post(buy_handler))
+        .nest_service("/static", ServeDir::new("static"));
 
     router.with_state(pool)
 }
@@ -38,12 +63,12 @@ fn app(pool: PgPool) -> Router {
 async fn create_user(State(pool): State<PgPool>) -> Result<String, (StatusCode, String)> {
     sqlx::query!(
         r#"
-    INSERT INTO users(username, email, notes) VALUES ('test_user2', 'user2@test.com', 'Test user');
-    "#
-    )
-    .execute(&pool)
-    .await
-    .map_err(internal_error)?;
+        INSERT INTO users(username, email, notes) VALUES ('test_user2', 'user2@test.com', 'Test user');
+        "#)
+        .execute(&pool)
+        .await
+        .map_err(internal_error)?;
+
     Ok("Ok".into())
 }
 
@@ -51,9 +76,9 @@ async fn create_user(State(pool): State<PgPool>) -> Result<String, (StatusCode, 
 async fn get_users(State(pool): State<PgPool>) -> Result<Markup, (StatusCode, String)> {
     let users = sqlx::query!(
         r#"
-    SELECT id, username, email, notes, join_timestamp
-    FROM users;
-    "#
+        SELECT id, username, email, notes, join_timestamp
+        FROM users;
+        "#
     )
     .fetch_all(&pool)
     .await
@@ -66,6 +91,68 @@ async fn get_users(State(pool): State<PgPool>) -> Result<Markup, (StatusCode, St
             }
         }
     })
+}
+
+#[debug_handler]
+async fn index(State(pool): State<PgPool>) -> Result<Markup, (StatusCode, String)> {
+    let products = get_active_products(&pool).await.map_err(internal_error)?;
+
+    Ok(html! {
+        (DOCTYPE)
+        html {
+            head {
+                link rel="stylesheet" href="/static/main.css";
+            }
+            body {
+                (quickbuy_component())
+                (products_table_component(&products))
+            }
+        }
+    })
+}
+
+async fn buy_handler(
+    State(pool): State<PgPool>,
+    Form(buy_request): Form<BuyRequest>,
+) -> Result<Markup, (StatusCode, String)> {
+    let quickbuy_type = parse_quickbuy_query(&buy_request.quickbuy).map_err(internal_error)?;
+
+    // Should not be here.
+    let products = get_active_products(&pool).await.map_err(internal_error)?;
+
+    Ok(match quickbuy_type {
+        QuickBuyType::Username { username } => html! {
+            (DOCTYPE)
+            html {
+                head {
+                    link rel="stylesheet" href="/static/main.css";
+                }
+                body {
+                    (clickable_products_table_component(&products, &username))
+                }
+            }
+        },
+        QuickBuyType::MultiBuy { username, products } => html! {
+            "Username: " (username) "Products: "
+            ol {
+                @for product in products {
+                    li { (product.product_name) " Amount: " (product.amount) }
+                }
+            }
+        },
+    })
+}
+
+async fn get_active_products(pool: &PgPool) -> Result<Vec<Product>, sqlx::Error> {
+    sqlx::query_as!(
+        Product,
+        r#"
+        SELECT id as "id: ProductId", name, price as "price: StregCents"
+        FROM products
+        WHERE active=true AND (deactivate_after_timestamp IS NULL OR deactivate_after_timestamp > now())
+        "#)
+        .fetch_all(pool)
+        .await
 }
 
 fn internal_error<E>(err: E) -> (StatusCode, String)

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,0 +1,1 @@
+pub mod buy_request;

--- a/src/protocol/buy_request.rs
+++ b/src/protocol/buy_request.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub struct BuyRequest {
+    pub quickbuy: String,
+}

--- a/src/quickbuy.rs
+++ b/src/quickbuy.rs
@@ -1,0 +1,1 @@
+pub mod parser;

--- a/src/quickbuy/parser.rs
+++ b/src/quickbuy/parser.rs
@@ -1,0 +1,187 @@
+use std::num::ParseIntError;
+
+use thiserror::Error;
+
+pub fn parse_quickbuy_query(quickbuy_query: &str) -> Result<QuickBuyType, QuickBuyParseError> {
+    let trimmed = quickbuy_query.trim();
+
+    let split = trimmed
+        .split(" ")
+        .filter(|&s| !s.is_empty())
+        .collect::<Vec<&str>>();
+    match split.len() {
+        0 => Err(QuickBuyParseError::EmptyQuery),
+        1 => Ok(QuickBuyType::Username {
+            username: split[0].into(),
+        }),
+        _ => Ok(parse_multi_buy_expression(&split)?),
+    }
+}
+
+fn parse_multi_buy_expression(split: &[&str]) -> Result<QuickBuyType, MultiBuyParseError> {
+    let username = split[0];
+    let rest = &split[1..];
+
+    let products = rest
+        .iter()
+        .map(|product| parse_multi_buy_product(product))
+        .collect::<Result<Vec<MultiBuyProduct>, MultiBuyParseError>>()?;
+
+    Ok(QuickBuyType::MultiBuy {
+        username: username.into(),
+        products,
+    })
+}
+
+fn parse_multi_buy_product(product_query: &str) -> Result<MultiBuyProduct, MultiBuyParseError> {
+    let split = product_query.split(":").collect::<Vec<&str>>();
+
+    match split.len() {
+        1 => Ok(MultiBuyProduct {
+            product_name: parse_product_name(split[0])?.into(),
+            amount: 1,
+        }),
+        2 => Ok(MultiBuyProduct {
+            product_name: parse_product_name(split[0])?.into(),
+            amount: split[1].parse::<u32>()?, // TODO: 0 should not be allowed.
+        }),
+        _ => Err(MultiBuyParseError::Syntax),
+    }
+}
+
+fn parse_product_name(product_name: &str) -> Result<&str, MultiBuyParseError> {
+    match product_name.len() {
+        0 => Err(MultiBuyParseError::EmptyProduct),
+        _ => Ok(product_name),
+    }
+}
+
+#[derive(Debug)]
+pub enum QuickBuyType {
+    Username {
+        username: String,
+    },
+    MultiBuy {
+        username: String,
+        products: Vec<MultiBuyProduct>,
+    },
+}
+
+#[derive(Debug)]
+pub struct MultiBuyProduct {
+    pub product_name: String,
+    pub amount: u32,
+}
+
+#[derive(Error, Debug)]
+pub enum QuickBuyParseError {
+    #[error("query is empty")]
+    EmptyQuery,
+
+    #[error(transparent)]
+    MultiBuy(#[from] MultiBuyParseError),
+}
+
+#[derive(Error, Debug)]
+pub enum MultiBuyParseError {
+    #[error("syntax error")]
+    Syntax,
+
+    #[error("empty product name")]
+    EmptyProduct,
+
+    #[error("invalid amount")]
+    InvalidAmount(#[from] ParseIntError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query() {
+        parse_and_expect_empty_query("");
+    }
+
+    #[test]
+    fn whitespace_query() {
+        parse_and_expect_empty_query(" ");
+    }
+
+    #[test]
+    fn username_query() {
+        let expected_username: String = "test_user".into();
+        let result = parse_quickbuy_query(&expected_username).unwrap();
+
+        assert!(
+            matches!(result, QuickBuyType::Username { username } if username == expected_username)
+        );
+    }
+
+    #[test]
+    fn multibuy_query() {
+        let result = parse_quickbuy_query("test_user kaffe øl:2 21:3").unwrap();
+
+        match result {
+            QuickBuyType::MultiBuy { username, products } => {
+                assert_eq!(username, "test_user");
+
+                let kaffe_product = &products[0];
+                let øl_product = &products[1];
+                let id_product = &products[2];
+
+                assert_eq!(kaffe_product.product_name, "kaffe");
+                assert_eq!(kaffe_product.amount, 1);
+
+                assert_eq!(øl_product.product_name, "øl");
+                assert_eq!(øl_product.amount, 2);
+
+                assert_eq!(id_product.product_name, "21");
+                assert_eq!(id_product.amount, 3);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn empty_product_multibuy_query() {
+        let error = parse_quickbuy_query("test_user :2").unwrap_err();
+
+        assert!(matches!(
+            error,
+            QuickBuyParseError::MultiBuy(MultiBuyParseError::EmptyProduct)
+        ))
+    }
+
+    #[test]
+    fn missing_amount_multibuy_query() {
+        parse_and_expect_invalid_amount_multibuy_query("test_user p:");
+    }
+
+    #[test]
+    fn negative_amount_multibuy_query() {
+        parse_and_expect_invalid_amount_multibuy_query("test_user p:-1");
+    }
+
+    #[test]
+    fn invalid_amount_multibuy_query() {
+        parse_and_expect_invalid_amount_multibuy_query("test_user p:x");
+    }
+
+    fn parse_and_expect_empty_query(query: &str) {
+        let result = parse_quickbuy_query(query);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+
+        assert!(matches!(error, QuickBuyParseError::EmptyQuery));
+    }
+
+    fn parse_and_expect_invalid_amount_multibuy_query(query: &str) {
+        let error = parse_quickbuy_query(query).unwrap_err();
+
+        assert!(matches!(
+            error,
+            QuickBuyParseError::MultiBuy(MultiBuyParseError::InvalidAmount(_))
+        ))
+    }
+}

--- a/static/main.css
+++ b/static/main.css
@@ -1,0 +1,3 @@
+.quickbuy-container {
+  margin: auto;
+}


### PR DESCRIPTION
![front page](https://github.com/user-attachments/assets/56af7f29-e41b-4d1a-921f-1f806f650a3f)

Add a page where users can see available products and buy them using the
quick-buy field.
If the user just types in their user name they get presented with a
clickable product menu where they can buy products.
Otherwise they can use the multi-buy functionality to buy multiple
products at once.

The buying functionality is NOT implemented in this PR and as such
usernames and products are not validated in the quick-buy query.

Changes:
- Add products table
- Add quick-buy parser
- Add streg cents
- Add CI format and linter checks
- Add scripts for starting and stopping a docker image with an empheral
  postgres database (gets cleared on stop)
- Add script for adding sample data to the database
- Serve files from the /static directory (should be done with a reverse
  proxy like nginx in production)