### PR TITLE
Quick-buy executor: Check product inactivity and add tests

### DIFF
--- a/fixtures/deposits.sql
+++ b/fixtures/deposits.sql
@@ -1,0 +1,3 @@
+INSERT INTO deposits(amount, note, user_id)
+VALUES
+  (10000, '$100 test deposit', 1);

--- a/fixtures/product_aliases.sql
+++ b/fixtures/product_aliases.sql
@@ -1,0 +1,8 @@
+INSERT INTO product_aliases(alias_name, product_id)
+VALUES
+  ('enabled',  1),
+  ('active',   1),
+  ('inactive', 3),
+  ('inactive_timestamp', 4),
+  ('expensive', 5),
+  ('overflow', 6);

--- a/fixtures/products.sql
+++ b/fixtures/products.sql
@@ -1,0 +1,8 @@
+INSERT INTO products(id, name, price, active, deactivate_after_timestamp)
+VALUES 
+  (1, 'Enabled',                  700 ,         true,  NULL),
+  (2, 'No aliases',               1200,         true,  NULL),
+  (3, 'Inactive',                 200,          false, NULL),
+  (4, 'Deactivated by Timestamp', 30000,        true,  '2024-09-01'),
+  (5, 'Expensive',                100000,       true,  NULL),
+  (6, 'Overflow trigger',         100000000000, true,  NULL);

--- a/fixtures/users.sql
+++ b/fixtures/users.sql
@@ -1,0 +1,3 @@
+INSERT INTO users(id, username, email, notes)
+VALUES
+  (1, 'test_user', 'test@email.com', 'test user');


### PR DESCRIPTION
Add fixtures with sample data to added in the database when used in tests.
Check that product is active.
Add tests.