### PR TITLE
Output status as json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,10 +1774,13 @@ name = "stregsystemet-rs"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "bytes",
  "chrono",
  "derive_more",
  "dotenv",
+ "mime",
  "serde",
+ "serde_json",
  "serde_with",
  "sqlx",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ axum = { version = "0.7", features = ["macros", "multipart"] }
 tokio = { version = "1.37", features = ["full"] }
 sqlx = { version = "0.8", features = ["postgres", "macros", "migrate", "runtime-tokio", "chrono", "uuid"] }
 serde = "1.0"
+serde_json = "1.0"
 serde_with = { version = "3.8", features = ["chrono_0_4"] }
 dotenv = "0.15"
 tracing = "0.1"
@@ -20,3 +21,5 @@ derive_more = { version = "1.0", features = ["full"] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6.0", features = ["fs", "trace"] }
 thiserror = "1.0.64"
+bytes = "1.0"
+mime = "0.3.16"

--- a/src/protocol/buy_request.rs
+++ b/src/protocol/buy_request.rs
@@ -1,6 +1,41 @@
+use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{
+    quickbuy::{executor::MultiBuyExecutorError, parser::QuickBuyParseError},
+    responses::result_json::HttpStatusCode,
+};
 
 #[derive(Deserialize, Serialize)]
 pub struct BuyRequest {
     pub quickbuy: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum BuyResponse {
+    Username { username: String },
+    MultiBuy,
+}
+
+#[derive(Error, Debug, Serialize)]
+pub enum BuyError {
+    #[error("parser error {0}")]
+    Parser(#[from] QuickBuyParseError),
+
+    #[error("executor error {0}")]
+    Executor(#[from] MultiBuyExecutorError),
+}
+
+impl HttpStatusCode for BuyError {
+    fn status_code(&self) -> axum::http::StatusCode {
+        match self {
+            BuyError::Parser(_) => StatusCode::BAD_REQUEST,
+            BuyError::Executor(multi_buy_executor_error) => match multi_buy_executor_error {
+                MultiBuyExecutorError::DbError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                _ => StatusCode::BAD_REQUEST,
+            },
+        }
+    }
 }

--- a/src/protocol/products/active_products_response.rs
+++ b/src/protocol/products/active_products_response.rs
@@ -1,6 +1,9 @@
+use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+use thiserror::Error;
 
-use crate::dso::product::ProductId;
+use crate::{dso::product::ProductId, responses::result_json::HttpStatusCode};
 
 #[derive(Deserialize, Serialize)]
 pub struct ActiveProductsResponse {
@@ -12,4 +15,20 @@ pub struct ActiveProduct {
     pub id: ProductId,
     pub name: String,
     pub price: String,
+}
+
+// TODO: Should not be here
+#[serde_as]
+#[derive(Error, Debug, Serialize)]
+#[error(transparent)]
+pub struct DatabaseError(
+    #[serde_as(as = "DisplayFromStr")]
+    #[from]
+    sqlx::Error,
+);
+
+impl HttpStatusCode for DatabaseError {
+    fn status_code(&self) -> axum::http::StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
 }

--- a/src/quickbuy/executor.rs
+++ b/src/quickbuy/executor.rs
@@ -1,3 +1,6 @@
+use serde::Serialize;
+use serde_with::serde_as;
+use serde_with::DisplayFromStr;
 use sqlx::{PgPool, Postgres, Transaction};
 use thiserror::Error;
 
@@ -203,10 +206,15 @@ async fn purchase_product(
     Ok(())
 }
 
-#[derive(Error, Debug)]
+#[serde_as]
+#[derive(Error, Debug, Serialize)]
 pub enum MultiBuyExecutorError {
     #[error("database error: {0}")]
-    DbError(#[from] sqlx::Error),
+    DbError(
+        #[serde_as(as = "DisplayFromStr")]
+        #[from]
+        sqlx::Error,
+    ),
 
     #[error("invalid username: {0}")]
     InvalidUsername(String),

--- a/src/quickbuy/parser.rs
+++ b/src/quickbuy/parser.rs
@@ -1,6 +1,7 @@
 use std::num::{NonZeroU32, ParseIntError};
 
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 use thiserror::Error;
 
 pub fn parse_quickbuy_query(quickbuy_query: &str) -> Result<QuickBuyType, QuickBuyParseError> {
@@ -74,7 +75,7 @@ pub struct MultiBuyProduct {
     pub amount: NonZeroU32,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize)]
 pub enum QuickBuyParseError {
     #[error("query is empty")]
     EmptyQuery,
@@ -83,7 +84,8 @@ pub enum QuickBuyParseError {
     MultiBuy(#[from] MultiBuyParseError),
 }
 
-#[derive(Error, Debug)]
+#[serde_as]
+#[derive(Error, Debug, Serialize)]
 pub enum MultiBuyParseError {
     #[error("syntax error")]
     Syntax,
@@ -92,7 +94,11 @@ pub enum MultiBuyParseError {
     EmptyProduct,
 
     #[error("invalid amount")]
-    InvalidAmount(#[from] ParseIntError),
+    InvalidAmount(
+        #[serde_as(as = "DisplayFromStr")]
+        #[from]
+        ParseIntError,
+    ),
 }
 
 #[cfg(test)]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -1,0 +1,1 @@
+pub mod result_json;

--- a/src/responses/result_json.rs
+++ b/src/responses/result_json.rs
@@ -1,0 +1,83 @@
+use std::error::Error;
+
+use axum::{
+    http::{header, HeaderValue, StatusCode},
+    response::IntoResponse,
+};
+use bytes::{BufMut, BytesMut};
+use derive_more::derive::{From, Into};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, From, Into)]
+#[must_use]
+pub struct ResultJson<T, E>(pub Result<T, E>);
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(tag = "status", content = "content")]
+enum ResponseWrapper<T, E>
+where
+    T: Serialize,
+    E: Serialize,
+    E: HttpStatusCode,
+{
+    Ok(T),
+    Error(E),
+}
+
+impl<T, E> ResponseWrapper<T, E>
+where
+    T: Serialize,
+    E: Serialize,
+    E: HttpStatusCode,
+{
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ResponseWrapper::Ok(_) => StatusCode::OK,
+            ResponseWrapper::Error(err) => err.status_code(),
+        }
+    }
+}
+
+impl<T, E> IntoResponse for ResultJson<T, E>
+where
+    T: Serialize,
+    E: Error,
+    E: Serialize,
+    E: HttpStatusCode,
+{
+    fn into_response(self) -> axum::response::Response {
+        // Much code is copied from axum/json.rs
+        let mut buf = BytesMut::with_capacity(128).writer();
+
+        let response_wrapper = match self.0 {
+            Ok(ok) => ResponseWrapper::Ok(ok),
+            Err(err) => ResponseWrapper::Error(err),
+        };
+
+        match serde_json::to_writer(&mut buf, &response_wrapper) {
+            Ok(()) => (
+                response_wrapper.status_code(),
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::APPLICATION_JSON.as_ref()),
+                )],
+                buf.into_inner().freeze(),
+            )
+                .into_response(),
+
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                )],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}
+
+pub trait HttpStatusCode {
+    fn status_code(&self) -> StatusCode;
+}


### PR DESCRIPTION
Add type ResultJson.
It works like a Result but it tells the user if it is ok or an error as json.

For example:
```json
{
  "status": "Ok",
  "content": "..."
}
```
or
```json
{
  "status": "Error",
  "content": "..."
}
```

Furthermore it allows the user to specify a http status code for the
error by implementing a function on the error type.